### PR TITLE
Fixes for crashes blindbat84 reported.

### DIFF
--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -2832,15 +2832,17 @@ function move(direction,pindex)
          end
          players[pindex].position = new_pos
          players[pindex].cursor_pos = offset_position(players[pindex].cursor_pos, direction,1)
-         if players[pindex].tile.previous ~= nil and players[pindex].tile.previous.type == "transport-belt" then
-            game.get_player(pindex).play_sound{path = "utility/metal_walking_sound"}
-            game.get_player(pindex).play_sound{path = "utility/metal_walking_sound"}
+         if players[pindex].tile.previous ~= nil
+            and players[pindex].tile.previous.valid
+            and players[pindex].tile.previous.type == "transport-belt"
+         then
             game.get_player(pindex).play_sound{path = "utility/metal_walking_sound"}
          else
             local tile = game.get_player(pindex).surface	.get_tile(new_pos.x, new_pos.y)
-            game.get_player(pindex).play_sound{path = "tile-walking/" .. tile.name}
-            game.get_player(pindex).play_sound{path = "tile-walking/" .. tile.name}
-            game.get_player(pindex).play_sound{path = "tile-walking/" .. tile.name}
+            local sound_path = "tile-walking/" .. tile.name
+            if game.is_valid_sound_path(sound_path) then
+               game.get_player(pindex).play_sound{path = "tile-walking/" .. tile.name}
+            end
          end
          read_tile(pindex)
          target(pindex)


### PR DESCRIPTION
checked if the tile.previous entity was valid before reading
checked if the soundpath was valid before playing
reduced triplicate calls to play to a singular one because it didn't seem like it queued them.