### PR TITLE
made players factorio global

### DIFF
--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -1,5 +1,4 @@
 
-players = {}
 groups = {}
 entity_types = {}
 production_types = {}
@@ -1345,6 +1344,10 @@ end
 
 
 function check_for_player(index)
+   if not players then
+      global.players = global.players or {}
+      players = global.players
+   end
    if players[index] == nil then
    initialize(game.get_player(index))
    return false
@@ -2972,16 +2975,17 @@ end
 
 
 function move_key(direction,event)
-   if not check_for_player(event.player_index) or players[pindex].menu == "prompt" then
+   local pindex = event.player_index
+   if not check_for_player(pindex) or players[pindex].menu == "prompt" then
       return 
    end
-   if players[event.player_index].in_menu and players[pindex].menu ~= "prompt" then
-      menu_cursor_move(direction,event.player_index)
-   elseif players[event.player_index].cursor then
-      players[event.player_index].cursor_pos = offset_position(players[event.player_index].cursor_pos, direction,1 + players[pindex].cursor_size*2)
+   if players[pindex].in_menu and players[pindex].menu ~= "prompt" then
+      menu_cursor_move(direction,pindex)
+   elseif players[pindex].cursor then
+      players[pindex].cursor_pos = offset_position(players[pindex].cursor_pos, direction,1 + players[pindex].cursor_size*2)
       if players[pindex].cursor_size == 0 then
          read_tile(pindex)
-         target(event.player_index)
+         target(pindex)
       else
          players[pindex].nearby.index = 1
          players[pindex].nearby.ents = scan_area(math.floor(players[pindex].cursor_pos.x)-players[pindex].cursor_size, math.floor(players[pindex].cursor_pos.y)-players[pindex].cursor_size, players[pindex].cursor_size * 2 + 1, players[pindex].cursor_size * 2 + 1, pindex)
@@ -2989,7 +2993,7 @@ function move_key(direction,event)
          read_scan_summary(pindex)
       end
    else
-      move(direction,event.player_index)
+      move(direction,pindex)
    end
 end
 
@@ -4522,7 +4526,13 @@ script.on_event(defines.events.on_player_cursor_stack_changed, function(event)
    end
 end)
 
+script.on_load(function()
+   players = global.players
+end)
 
+script.on_init(function()
+   global.players={}
+end)
 
 script.on_event(defines.events.on_cutscene_cancelled, function(event)
    check_for_player(event.player_index)

--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -1994,7 +1994,7 @@ function initialize(player)
          travel = {}
       }
    end
-   player.character_reach_distance_bonus = math.max(player.character_reach_distance_bonus, 1)
+   --player.character_reach_distance_bonus = math.max(player.character_reach_distance_bonus, 1)
 --   player.surface.daytime = .5
    players[index] = {
       player = player,
@@ -2196,37 +2196,35 @@ function initialize(player)
 --   player.force.research_all_technologies()
    end
 
-   script.on_event(defines.events.on_player_changed_position,function(event)
-      local pindex = event.player_index
-      if not check_for_player(pindex) then
-               return
-      end
-      if players[pindex].walk == 2 then
-         local pos = game.get_player(pindex).position
-         pos.x = math.floor(pos.x)+0.5
-         pos.y = math.floor(pos.y)+0.5
-         if game.get_player(pindex).walking_state.direction ~= players[pindex].direction then
-            players[pindex].direction = game.get_player(pindex).walking_state.direction
-            local new_pos = offset_position(pos,players[pindex].direction,1)
-            players[pindex].cursor_pos = new_pos
-            players[pindex].position = pos
---            target(pindex)
-         else
-         
-            players[pindex].cursor_pos.x = players[pindex].cursor_pos.x + pos.x - players[pindex].position.x
-            players[pindex].cursor_pos.y = players[pindex].cursor_pos.y + pos.y - players[pindex].position.y
-            players[pindex].position = pos
-         end
-         -- print("checking:".. players[pindex].cursor_pos.x .. "," .. players[pindex].cursor_pos.y)
-         if not game.get_player(pindex).surface.can_place_entity{name = "character", position = players[pindex].cursor_pos} then
-            read_tile(pindex)
-            target(pindex)
-         end
-      end
-   end)
-
-
 end
+
+script.on_event(defines.events.on_player_changed_position,function(event)
+   local pindex = event.player_index
+   if not check_for_player(pindex) then
+      return
+   end
+   if players[pindex].walk == 2 then
+      local pos = center_of_tile(game.get_player(pindex).position)
+      if game.get_player(pindex).walking_state.direction ~= players[pindex].direction then
+         players[pindex].direction = game.get_player(pindex).walking_state.direction
+         local new_pos = offset_position(pos,players[pindex].direction,1)
+         players[pindex].cursor_pos = new_pos
+         players[pindex].position = pos
+--            target(pindex)
+      else
+      
+         players[pindex].cursor_pos.x = players[pindex].cursor_pos.x + pos.x - players[pindex].position.x
+         players[pindex].cursor_pos.y = players[pindex].cursor_pos.y + pos.y - players[pindex].position.y
+         players[pindex].position = pos
+      end
+      -- print("checking:".. players[pindex].cursor_pos.x .. "," .. players[pindex].cursor_pos.y)
+      if not game.get_player(pindex).surface.can_place_entity{name = "character", position = players[pindex].cursor_pos} then
+         read_tile(pindex)
+         target(pindex)
+      end
+   end
+end)
+
 
 
 function menu_cursor_move(direction,pindex)

--- a/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
+++ b/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
@@ -1,0 +1,2 @@
+
+global.players = global.players or {}


### PR DESCRIPTION
This adds an on_load event to make a local reference to the global players table.
Adds a migration script to add an empty global players table
changes all event.player_index to local pindex in move_key

should fix issue #1