### PR TITLE
autocalibration

### DIFF
--- a/main.py
+++ b/main.py
@@ -512,7 +512,7 @@ while not exit:
             print(coordstring)
             coords = [int(coordstring[0]), int(coordstring[1])]
             print(coords)
-            gui.moveTo(coords[0], coords[1])
+            gui.moveTo(coords[0], coords[1],_pause=False)
 #         tolk.output(line[10:].decode(), True)
         elif len(line) > 16 and line[-17:-2] == b"Saving finished":
           tolk.output("Saving Complete", True)

--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -4656,6 +4656,7 @@ script.on_event("list-warnings", function(event)
 
    end
 end)
+
 script.on_event("open-fast-travel", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then
@@ -4698,3 +4699,7 @@ end)
       event.element.destroy()
    end
 end)   
+
+script.on_event({"fa-alt-zoom-in","fa-alt-zoom-out","fa-zoom-in","fa-zoom-out"}, function(event)
+   print(serpent.line(event))
+end)

--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -1,5 +1,4 @@
 
-players = {}
 groups = {}
 entity_types = {}
 production_types = {}
@@ -1345,6 +1344,10 @@ end
 
 
 function check_for_player(index)
+   if not players then
+      global.players = global.players or {}
+      players = global.players
+   end
    if players[index] == nil then
    initialize(game.get_player(index))
    return false
@@ -2972,16 +2975,17 @@ end
 
 
 function move_key(direction,event)
-   if not check_for_player(event.player_index) or players[pindex].menu == "prompt" then
+   local pindex = event.player_index
+   if not check_for_player(pindex) or players[pindex].menu == "prompt" then
       return 
    end
-   if players[event.player_index].in_menu and players[pindex].menu ~= "prompt" then
-      menu_cursor_move(direction,event.player_index)
-   elseif players[event.player_index].cursor then
-      players[event.player_index].cursor_pos = offset_position(players[event.player_index].cursor_pos, direction,1 + players[pindex].cursor_size*2)
+   if players[pindex].in_menu and players[pindex].menu ~= "prompt" then
+      menu_cursor_move(direction,pindex)
+   elseif players[pindex].cursor then
+      players[pindex].cursor_pos = offset_position(players[pindex].cursor_pos, direction,1 + players[pindex].cursor_size*2)
       if players[pindex].cursor_size == 0 then
          read_tile(pindex)
-         target(event.player_index)
+         target(pindex)
       else
          players[pindex].nearby.index = 1
          players[pindex].nearby.ents = scan_area(math.floor(players[pindex].cursor_pos.x)-players[pindex].cursor_size, math.floor(players[pindex].cursor_pos.y)-players[pindex].cursor_size, players[pindex].cursor_size * 2 + 1, players[pindex].cursor_size * 2 + 1, pindex)
@@ -2989,7 +2993,7 @@ function move_key(direction,event)
          read_scan_summary(pindex)
       end
    else
-      move(direction,event.player_index)
+      move(direction,pindex)
    end
 end
 
@@ -4522,7 +4526,13 @@ script.on_event(defines.events.on_player_cursor_stack_changed, function(event)
    end
 end)
 
+script.on_load(function()
+   players = global.players
+end)
 
+script.on_init(function()
+   global.players={}
+end)
 
 script.on_event(defines.events.on_cutscene_cancelled, function(event)
    check_for_player(event.player_index)

--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -1,3 +1,4 @@
+require('zoom')
 
 groups = {}
 entity_types = {}
@@ -1217,77 +1218,22 @@ function target(pindex)
    if #players[pindex].tile.ents > 0 then
          move_cursor_map(players[pindex].tile.ents[players[pindex].tile.index - 1].position,pindex)
    else
-         move_cursor(math.floor(players[pindex].resolution.width/2), math.floor(players[pindex].resolution.height), pindex)
+         move_cursor_map(players[pindex].cursor_pos, pindex)
    end
 end
 function move_cursor_map(position,pindex)
-   player = game.get_player(pindex)
-   move_cursor((position.x-player.position.x)*players[pindex].scale.x + (players[pindex].resolution.width/2), (position.y - player.position.y) * players[pindex].scale.y + (players[pindex].resolution.height/2), pindex)
+   local player = players[pindex]
+   local pixels = mult_position( sub_position(position, player.position), 32*player.zoom)
+   local screen = game.players[pindex].display_resolution
+   screen = {x = screen.width, y = screen.height}
+   pixels = add_position(pixels,mult_position(screen,0.5))
+   move_cursor(pixels.x, pixels.y, pindex)
 end
 function move_cursor(x,y, pindex)
-   if x >= 0 and y >=0 and x < players[pindex].resolution.width and y < players[pindex].resolution.height then
+   if x >= 0 and y >=0 and x < game.players[pindex].display_resolution.width and y < game.players[pindex].display_resolution.height then
       print ("setCursor " .. math.ceil(x) .. "," .. math.ceil(y))
    end
 end
-
-function scale_stop(position, pindex)
-   player = game.get_player(pindex)
-   move_cursor(players[pindex].resolution.width/2, players[pindex].resolution.height/2, pindex)
-   x1 = player.position.x
-   y1 = player.position.y
-   x2 = position.x
-   y2 = position.y
-   dx = math.abs(x2-x1)
-   dy = math.abs(y2-y1)
-   pptx = players[pindex].resolution.width/dx/2
-   ppty = players[pindex].resolution.height/dy/2
-   players[pindex].scale.x = math.floor(pptx + .5)
-   players[pindex].scale.y = math.floor(ppty + .5)
-
-   local success = true
-   if pptx > 50 or ppty > 50 then
-      success = false
-   end
-   printout("Callibration complete", pindex)
-   game.speed = 1
-   players[pindex].in_menu = false
-   players[pindex].menu = "none"
-   local check = true
-   for i = 1, #players,1 do
-      if players[i].menu == "prompt" then
-         check = false
-      end
-   end
-   if check then
-      script.on_event("prompt", nil)
-   end
-   if not(success) then
-      scale_start(pindex)
-   end
-end
-
-function scale_start(pindex)
-   local player = game.get_player(pindex)
-   players[pindex].resolution = player.display_resolution
-   print ("resx="..players[pindex].resolution.width)
-   print ("resy="..players[pindex].resolution.height)
-      
-   move_cursor(0,0,pindex)
-   if #players < 2 then
---      game.speed = .1
-      end
-   printout("Calibration Started.  Press space to continue", pindex)
-   players[pindex].in_menu = true
-   players[pindex].menu = "prompt"
-   script.on_event("prompt", function(event)
-      if event.player_index == pindex then
-         scale_stop(event.cursor_position,pindex)
-      end
-   end)
-      
-end
-
-
 
 function tile_cycle(pindex)
    players[pindex].tile.index = players[pindex].tile.index + 1
@@ -1995,20 +1941,18 @@ function initialize(player)
       }
    end
    --player.character_reach_distance_bonus = math.max(player.character_reach_distance_bonus, 1)
---   player.surface.daytime = .5
+   local character = player.cutscene_character or player.character
    players[index] = {
       player = player,
       in_menu = false,
       in_item_selector = false,
-      on_target = false,
       menu = "none",
       cursor = false,
       cursor_pos = nil,
       cursor_size = 0 ,
-      scale = {x,y},
       num_elements = 0,
-      player_direction = player.walking_state.direction,
-      position = {x= math.floor(player.position.x) + .5, y= math.floor(player.position.y)+.5},
+      player_direction = character.walking_state.direction,
+      position = center_of_tile(character.position),
       walk = 0,
       move_queue = {},
       building_direction = 0,
@@ -2029,8 +1973,9 @@ function initialize(player)
       item_cache = {},
       item_selector = {},
       travel = {},
-      resolution = nil
+      zoom = 1
    }
+
    players[index].cursor_pos = offset_position(players[index].position,players[index].player_direction,1)
    players[index].nearby = {
       index = 0,
@@ -2125,8 +2070,6 @@ function initialize(player)
    }
 
       
-
-   scale_start(index)
 
    local recipes = player.force.recipes
    local types = {}
@@ -2865,7 +2808,24 @@ function menu_cursor_right(pindex)
    end
 end
 
+function on_player_join(pindex)
+   fix_zoom(pindex)
+end
 
+script.on_event(defines.events.on_player_joined_game,function(event)
+   on_player_join(event.player_index)
+end)
+
+local should_single_player_join_in = 3
+function on_tick(event)
+   if should_single_player_join_in > 0 then
+      should_single_player_join_in = should_single_player_join_in - 1
+      if should_single_player_join_in == 0 and not game.is_multiplayer() then
+         on_player_join(game.connected_players[1].index)
+      end
+   end
+   move_characters(event)
+end
 
 function move_characters(event)
    for pindex, player in pairs(players) do
@@ -2896,8 +2856,20 @@ function move_characters(event)
       end
    end
 end
-script.on_event({defines.events.on_tick},move_characters)
+script.on_event({defines.events.on_tick},on_tick)
 
+
+function add_position(p1,p2)
+   return { x = p1.x + p2.x, y = p1.y + p2.y}
+end
+
+function sub_position(p1,p2)
+   return { x = p1.x - p2.x, y = p1.y - p2.y}
+end
+
+function mult_position(p,m)
+   return { x = p.x * m, y = p.y * m }
+end
 
 function offset_position(oldpos,direction,distance)
    if direction == defines.direction.north then
@@ -4538,6 +4510,7 @@ script.on_event(defines.events.on_cutscene_cancelled, function(event)
 end)
 
 script.on_event(defines.events.on_player_created, function(event)
+   initialize(game.players[event.player_index])
    if not game.is_multiplayer() then
       printout("Press tab to continue.", 0)
    end
@@ -4626,7 +4599,7 @@ end)
 
 script.on_event("recalibrate",function(event)
    pindex = event.player_index
-   scale_start(pindex)
+   fix_zoom(pindex)
 end)
 
 script.on_event("read-hand",function(event)
@@ -4663,7 +4636,6 @@ script.on_event("open-fast-travel", function(event)
       return
    end
    if players[pindex].in_menu == false then
-      move_cursor(math.floor(players[pindex].resolution.width/2), math.floor(players[pindex].resolution.height/2), pindex)
       players[pindex].menu = "travel"
       players[pindex].in_menu = true
       players[pindex].travel.index = {x = 1, y = 0}
@@ -4681,7 +4653,7 @@ script.on_event("open-fast-travel", function(event)
 end)
 
 
-   script.on_event(defines.events.on_gui_confirmed,function(event)
+script.on_event(defines.events.on_gui_confirmed,function(event)
    if players[pindex].menu == "travel" then
       if players[pindex].travel.creating then
          players[pindex].travel.creating = false
@@ -4698,8 +4670,4 @@ end)
       players[pindex].travel.index.x = 1
       event.element.destroy()
    end
-end)   
-
-script.on_event({"fa-alt-zoom-in","fa-alt-zoom-out","fa-zoom-in","fa-zoom-out"}, function(event)
-   print(serpent.line(event))
 end)

--- a/mods/FactorioAccess_0.0.1/control.lua
+++ b/mods/FactorioAccess_0.0.1/control.lua
@@ -1994,7 +1994,7 @@ function initialize(player)
          travel = {}
       }
    end
-   player.character_reach_distance_bonus = math.max(player.character_reach_distance_bonus, 1)
+   --player.character_reach_distance_bonus = math.max(player.character_reach_distance_bonus, 1)
 --   player.surface.daytime = .5
    players[index] = {
       player = player,
@@ -2196,37 +2196,35 @@ function initialize(player)
 --   player.force.research_all_technologies()
    end
 
-   script.on_event(defines.events.on_player_changed_position,function(event)
-      local pindex = event.player_index
-      if not check_for_player(pindex) then
-               return
-      end
-      if players[pindex].walk == 2 then
-         local pos = game.get_player(pindex).position
-         pos.x = math.floor(pos.x)+0.5
-         pos.y = math.floor(pos.y)+0.5
-         if game.get_player(pindex).walking_state.direction ~= players[pindex].direction then
-            players[pindex].direction = game.get_player(pindex).walking_state.direction
-            local new_pos = offset_position(pos,players[pindex].direction,1)
-            players[pindex].cursor_pos = new_pos
-            players[pindex].position = pos
---            target(pindex)
-         else
-         
-            players[pindex].cursor_pos.x = players[pindex].cursor_pos.x + pos.x - players[pindex].position.x
-            players[pindex].cursor_pos.y = players[pindex].cursor_pos.y + pos.y - players[pindex].position.y
-            players[pindex].position = pos
-         end
-         -- print("checking:".. players[pindex].cursor_pos.x .. "," .. players[pindex].cursor_pos.y)
-         if not game.get_player(pindex).surface.can_place_entity{name = "character", position = players[pindex].cursor_pos} then
-            read_tile(pindex)
-            target(pindex)
-         end
-      end
-   end)
-
-
 end
+
+script.on_event(defines.events.on_player_changed_position,function(event)
+   local pindex = event.player_index
+   if not check_for_player(pindex) then
+      return
+   end
+   if players[pindex].walk == 2 then
+      local pos = center_of_tile(game.get_player(pindex).position)
+      if game.get_player(pindex).walking_state.direction ~= players[pindex].direction then
+         players[pindex].direction = game.get_player(pindex).walking_state.direction
+         local new_pos = offset_position(pos,players[pindex].direction,1)
+         players[pindex].cursor_pos = new_pos
+         players[pindex].position = pos
+--            target(pindex)
+      else
+      
+         players[pindex].cursor_pos.x = players[pindex].cursor_pos.x + pos.x - players[pindex].position.x
+         players[pindex].cursor_pos.y = players[pindex].cursor_pos.y + pos.y - players[pindex].position.y
+         players[pindex].position = pos
+      end
+      -- print("checking:".. players[pindex].cursor_pos.x .. "," .. players[pindex].cursor_pos.y)
+      if not game.get_player(pindex).surface.can_place_entity{name = "character", position = players[pindex].cursor_pos} then
+         read_tile(pindex)
+         target(pindex)
+      end
+   end
+end)
+
 
 
 function menu_cursor_move(direction,pindex)

--- a/mods/FactorioAccess_0.0.1/data.lua
+++ b/mods/FactorioAccess_0.0.1/data.lua
@@ -481,6 +481,38 @@ data:extend({
     name = "open-fast-travel",
     key_sequence = "V",
     consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "fa-alt-zoom-in",
+    key_sequence = "X",
+    linked_game_control = "alt-zoom-in",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "fa-alt-zoom-out",
+    key_sequence = "X",
+    linked_game_control = "alt-zoom-out",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "fa-zoom-out",
+    key_sequence = "X",
+    linked_game_control = "zoom-out",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "fa-zoom-in",
+    key_sequence = "X",
+    linked_game_control = "zoom-in",
+    consuming = "none"
 }
 
 

--- a/mods/FactorioAccess_0.0.1/data.lua
+++ b/mods/FactorioAccess_0.0.1/data.lua
@@ -513,7 +513,22 @@ data:extend({
     key_sequence = "X",
     linked_game_control = "zoom-in",
     consuming = "none"
-}
+},
 
+{
+    type = "custom-input",
+    name = "fa-debug-reset-zoom-2x",
+    key_sequence = "X",
+    linked_game_control = "debug-reset-zoom-2x",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "fa-debug-reset-zoom",
+    key_sequence = "X",
+    linked_game_control = "debug-reset-zoom",
+    consuming = "none"
+}
 
 })

--- a/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
+++ b/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
@@ -1,2 +1,0 @@
-
-global.players = global.players or {}

--- a/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
+++ b/mods/FactorioAccess_0.0.1/migrations/add_global_players.lua
@@ -1,0 +1,2 @@
+
+global.players = global.players or {}

--- a/mods/FactorioAccess_0.0.1/migrations/for_0.1.4.lua
+++ b/mods/FactorioAccess_0.0.1/migrations/for_0.1.4.lua
@@ -1,0 +1,7 @@
+
+global.players = global.players or {}
+
+
+for _,player in pairs(global.players) do
+   player.zoom = player.zoom or 1
+end

--- a/mods/FactorioAccess_0.0.1/zoom.lua
+++ b/mods/FactorioAccess_0.0.1/zoom.lua
@@ -1,0 +1,60 @@
+
+
+local MIN_ZOOM = 0.275
+local MAX_ZOOM = 3.233
+
+local ZOOM_PER_TICK = 1.104086977
+
+local ln_zoom = math.log(ZOOM_PER_TICK)
+
+
+function get_zoom_tick(pindex)
+   return math.floor(math.log(global.players[pindex].zoom)/ln_zoom + 0.5)
+end
+
+function tick_to_zoom(zoom_tick)
+   return ZOOM_PER_TICK ^ zoom_tick
+end
+
+function fix_zoom(pindex)
+   game.players[pindex].zoom = global.players[pindex].zoom
+end
+
+function zoom_change(pindex,etick,change_by_tick)
+   if global.players[pindex].last_zoom_event_tick == etick then
+      return
+   end
+   global.players[pindex].last_zoom_event_tick == etick
+   if game.players[pindex].render_mode == defines.render_mode.game then
+      local tick = zoom_to_tick(pindex)
+      tick = tick + change_by_tick
+      local zoom = tick_to_zoom(tick)
+      if zoom < MAX_ZOOM and zoom > MIN_ZOOM then
+         global.players[pindex].zoom = zoom
+      end
+   end
+end
+
+function zoom_in(event)
+   zoom_change(event.player_index, event.tick, 1)
+end
+
+function zoom_out(event)
+   zoom_change(event.player_index, event.tick, -1)
+end
+
+
+
+script.on_event("fa-zoom-in" , zoom_in )
+script.on_event("fa-zoom-out", zoom_out)
+script.on_event(defines.events.on_cutscene_waypoint_reached,function(event)
+   if game.players[event.player_index].render_mode == defines.render_mode.game then
+      fix_zoom(event.player_index)
+   end
+end)
+script.on_event("fa-debug-reset-zoom",function(event)
+   global.players[event.player_index].zoom = 1
+end)
+script.on_event("fa-debug-reset-zoom-2x",function(event)
+   global.players[event.player_index].zoom = 2
+end)

--- a/mods/FactorioAccess_0.0.1/zoom.lua
+++ b/mods/FactorioAccess_0.0.1/zoom.lua
@@ -1,7 +1,7 @@
 
 
 local MIN_ZOOM = 0.275
-local MAX_ZOOM = 3.233
+local MAX_ZOOM = 3.282
 
 local ZOOM_PER_TICK = 1.104086977
 
@@ -21,16 +21,18 @@ function fix_zoom(pindex)
 end
 
 function zoom_change(pindex,etick,change_by_tick)
-   if global.players[pindex].last_zoom_event_tick == etick then
-      return
-   end
-   global.players[pindex].last_zoom_event_tick == etick
+   -- if global.players[pindex].last_zoom_event_tick == etick then
+      -- print("maybe duplicate")
+      -- return
+   -- end
+   -- global.players[pindex].last_zoom_event_tick = etick
    if game.players[pindex].render_mode == defines.render_mode.game then
-      local tick = zoom_to_tick(pindex)
+      local tick = get_zoom_tick(pindex)
       tick = tick + change_by_tick
       local zoom = tick_to_zoom(tick)
       if zoom < MAX_ZOOM and zoom > MIN_ZOOM then
          global.players[pindex].zoom = zoom
+         target(pindex)
       end
    end
 end


### PR DESCRIPTION
removes the mouse based calibration in favor of tracking the zoom level. Still keeps ctrl+end to fix the zoom in case it somehow gets screwed up, but I haven't had it mess up in any of my testing.

This adds to a migration script to make sure players can continue from previous saves without issue.

Note that tab is still needed when starting a new game to skip the cutscene, or to clear the welcome message if the player lets the cutscene play out in full.

Based on the global pr so that can be ignored now.