### PR TITLE
New shortcut: Smart insert all stacks

### DIFF
--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -4536,7 +4536,7 @@ script.on_event("shift-click", function(event)
             local stack = players[pindex].building.sectors[players[pindex].building.sector].inventory[players[pindex].building.index]
             if stack.valid and stack.valid_for_read then
                if game.get_player(pindex).can_insert(stack) then
-                  game.get_player(pindex).play_sound{path = "utility/inventory_click"}
+                  game.get_player(pindex).play_sound{path = "utility/inventory_move"}
                   local result = stack.name
                   local inserted = game.get_player(pindex).insert(stack)
                   players[pindex].building.sectors[players[pindex].building.sector].inventory.remove{name = stack.name, count = inserted}
@@ -4555,6 +4555,7 @@ script.on_event("shift-click", function(event)
                local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
                if stack.valid and stack.valid_for_read then
                   if players[pindex].building.ent.can_insert(stack) then
+                     game.get_player(pindex).play_sound{path = "utility/inventory_move"}
                      local result = stack.name
                      local inserted = players[pindex].building.ent.insert(stack)
                      players[pindex].inventory.lua_inventory.remove{name = stack.name, count = inserted}
@@ -4589,115 +4590,119 @@ script.on_event("control-click", function(event)
 
    if players[pindex].in_menu then
       if players[pindex].menu == "building" then
-         if players[pindex].building.sector <= #players[pindex].building.sectors and #players[pindex].building.sectors[players[pindex].building.sector].inventory > 0 and players[pindex].building.sectors[players[pindex].building.sector].name ~= "Fluid" then
-            --This is the section where we move from the building to the player.
-            local result = "Moved "
-            local moved_count = 0
-            local inv_full = false
-            local announce_limit = 4 --List at most this number of moved stacks
-            local stack_name = " "
-			local next_stack_name = "   "
-			local inserted_total = 0
-			
-            for i = 1,2,1 do --todo correctly phrase this line as: "for every stack in the selected building inventory do"
-               local stack = players[pindex].building.sectors[players[pindex].building.sector].inventory[players[pindex].building.index]
-               if stack.valid and stack.valid_for_read then
-                  if game.get_player(pindex).can_insert(stack) then
-                     game.get_player(pindex).play_sound{path = "utility/inventory_click"}
-                     stack_name = stack.name
-                     local inserted = game.get_player(pindex).insert(stack)
-                     players[pindex].building.sectors[players[pindex].building.sector].inventory.remove{name = stack.name, count = inserted}
-                     inserted_total = inserted_total + inserted
-					 --Now explain what was moved
-					 next_stack_name = "     " --todo fetch this
-					 if stack_name ~= next_stack_name then
-					    --Moving the final stack of an item type
-					    local next_phrase = " "
-					    if moved_count == 0 then
-					       next_phrase = " " .. inserted_total .. " " .. stack_name .. " "
-					    else if moved_count < announce_limit then
-					       next_phrase = " and " .. inserted_total .. " " .. stack_name .. " "
-                        else if moved_count == announce_limit then
-                           next_phrase = " and other items "
-                        end
-						inserted_total = 0
-					 else 
-					    --Moving first/middle stacks of the same item type: Say nothing
-					    next_phrase = " "
-					 end
-                     moved_count = moved_count + 1
-                     result = result .. next_phrase
-                  else
-                     inv_full = true
-                  end
-               end
-            end --end of for loop
-            if moved_count == 0 then
-               result = result .. " nothing "
-            end
-            result = result .. " to player's inventory. "
-            if inv_full == true then
-               result = result .. " Inventory full. "
-            end
-            printout(result, pindex)
-         else
-            local offset = 1
-            if players[pindex].building.recipe_list ~= nil then
-               offset = offset + 1
-            end
-            if players[pindex].building.sector == #players[pindex].building.sectors + offset then
-               --This is the section where we move from the player to the building.
-               local result = "Moved "
-               local moved_count = 0
-               local inv_full = false
-               local announce_limit = 4 --List at most this number of moved stacks
-               local stack_name = " "
-               for i = 1,2,1 do --todo correctly phrase this line as: "for every stack in the player inventory do"
-                  local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
-                  if stack.valid and stack.valid_for_read then
-                     if players[pindex].building.ent.can_insert(stack) then
-                        stack_name = stack.name
-                        local inserted = players[pindex].building.ent.insert(stack)
-                        players[pindex].inventory.lua_inventory.remove{name = stack.name, count = inserted}
-                        inserted_total = inserted_total + inserted
-                        --Now explain what was moved
-						next_stack_name = "     " --todo fetch this
-					    if stack_name ~= next_stack_name then
-   					       --Moving the final stack of an item type
-					       local next_phrase = " "
-					       if moved_count == 0 then
-  					          next_phrase = " " .. inserted_total .. " " .. stack_name .. " "
-					       else if moved_count < announce_limit then
-					          next_phrase = " and " .. inserted_total .. " " .. stack_name .. " "
-                           else if moved_count == announce_limit then
-                              next_phrase = " and other items "
-                           end
-						   inserted_total = 0
-					    else 
-					       --Moving first/middle stacks of the same item type: Say nothing
-					       next_phrase = " "
-					    end
-                        moved_count = moved_count + 1
-                        result = result .. next_phrase
-                     else
-                        inv_full = true
-                     end
-                  end
-               end --end of for loop
-               if moved_count == 0 then
-                  result = result .. " nothing "
-               end
-               result = result .. " to building inventory. "
-               if inv_full == true then
-                  result = result .. " Inventory full. "
-               end
-               printout(result, pindex)
-            end
-         end
+         do_multi_stack_transfer(1,pindex)
       end
    end
 end
 )
+
+script.on_event("control-right-click", function(event)
+   pindex = event.player_index
+   if not check_for_player(pindex) then
+      return
+   end
+
+   if players[pindex].in_menu then
+      if players[pindex].menu == "building" then
+         do_multi_stack_transfer(0.5,pindex)
+      end
+   end
+end
+)
+
+function do_multi_stack_transfer(ratio,pindex)
+   local result = {""}
+   local sector = players[pindex].building.sectors[players[pindex].building.sector]
+   if sector and #sector.inventory > 0 and sector.name ~= "Fluid" then
+      --This is the section where we move from the building to the player.
+      local item_name=""
+      local stack = sector.inventory[players[pindex].building.index]
+      if stack and stack.valid and stack.valid_for_read then
+         item_name = stack.name
+      end
+      
+      local moved, full = transfer_inventory{from=sector.inventory,to=game.players[pindex],name=item_name,ratio=ratio}
+      if full then
+         table.insert(result,{"inventory-full-message.main"})
+         table.insert(result,", ")
+      end
+      if table_size(moved) == 0 then
+         table.insert(result,{"access.grabbed-nothing"})
+      else
+         game.get_player(pindex).play_sound{path = "utility/inventory_move"}
+         local item_list={""}
+         for name, amount in pairs(moved) do
+            table.insert(item_list,{"access.item-quantity",game.item_prototypes[name].localised_name,amount})
+            table.insert(item_list,", ")
+         end
+         --trim traling comma off
+         item_list[#item_list]=nil
+         table.insert(result,{"access.grabbed-stuff",item_list})
+      end
+      
+   else
+      local offset = 1
+      if players[pindex].building.recipe_list ~= nil then
+         offset = offset + 1
+      end
+      if players[pindex].building.sector == #players[pindex].building.sectors + offset then
+         --This is the section where we move from the player to the building.
+         local item_name=""
+         local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
+         if stack and stack.valid and stack.valid_for_read then
+            item_name = stack.name
+         end
+         
+         local moved, full = transfer_inventory{from=game.players[pindex].get_main_inventory(),to=players[pindex].building.ent,name=item_name,ratio=ratio}
+         
+         if full then
+            table.insert(result,"Inventory full. ")
+         end
+         if table_size(moved) == 0 then
+            table.insert(result,{"access.placed-nothing"})
+         else
+            game.get_player(pindex).play_sound{path = "utility/inventory_move"}
+            local item_list={""}
+            for name, amount in pairs(moved) do
+               table.insert(item_list,{"access.item-quantity",game.item_prototypes[name].localised_name,amount})
+               table.insert(item_list,", ")
+            end
+            --trim traling comma off
+            item_list[#item_list]=nil
+            table.insert(result,{"access.placed-stuff",item_list})
+         end
+      end
+   end
+   printout(result, pindex)
+end
+
+
+function transfer_inventory(args)
+   args.name = args.name or ""
+   args.ratio = args.ratio or 1
+   local transfer_list={}
+   if args.name ~= "" then
+      transfer_list[args.name] = args.from.get_item_count(args.name)
+   else
+      transfer_list = args.from.get_contents()
+   end
+   local full=false
+   res = {}
+   for name, amount in pairs(transfer_list) do
+      amount = math.ceil(amount * args.ratio)
+      local actual_amount = args.to.insert({name=name, count=amount})
+      if actual_amount ~= amount then
+         print(name,amount,actual_amount)
+         amount = actual_amount
+         full = true
+      end
+      if amount > 0 then
+         res[name] = amount
+         args.from.remove({name=name, count=amount})
+      end
+   end
+   return res, full
+end
 
 script.on_event("right-click", function(event)
    pindex = event.player_index

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -4575,12 +4575,9 @@ end
 )
 
 
---[[ New shortcut: Smart insert all stacks
---Main Idea: When you press control-click when a building inventory is open, the game tries to fast-transfer every stack from one inventory to the other, one by one. It announces every successfully moved stack up until a predetermined limit, after which it says "and other items".
---The code is mostly copied from the shift-click script in control.lua, and it puts the functional side of that into for loops.
---todo: properly define the for loop headers to make the code go through the entire entity inventory stack by stack
---Added feature: If multiple stacks of the same item are moved, the total count is announced instead.
---Not tested!
+--[[Imitates vanilla behavior: 
+* Control click an item in an inventory to try smart transfer ALL of it. 
+* Control click an empty slot to try to smart transfer ALL items from that inventory.
 ]]
 script.on_event("control-click", function(event)
    pindex = event.player_index
@@ -4596,6 +4593,10 @@ script.on_event("control-click", function(event)
 end
 )
 
+--[[Imitates vanilla behavior: 
+* Control click an item in an inventory to try smart transfer HALF of it. 
+* Control click an empty slot to try to smart transfer HALF of all items from that inventory.
+]]
 script.on_event("control-right-click", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then
@@ -4610,6 +4611,9 @@ script.on_event("control-right-click", function(event)
 end
 )
 
+--[[Manages inventory transfers that are bigger than one stack. 
+* Has checks and printouts!
+]]
 function do_multi_stack_transfer(ratio,pindex)
    local result = {""}
    local sector = players[pindex].building.sectors[players[pindex].building.sector]
@@ -4676,7 +4680,11 @@ function do_multi_stack_transfer(ratio,pindex)
    printout(result, pindex)
 end
 
-
+--[[Transfers multiple stacks of a specific item (or all items) to/from the player inventory from/to a building inventory.
+* item name / empty string to indicate transfering everything
+* ratio (between 0 and 1), the ratio of the total count to transder for each item.
+* Has no checks or printouts!
+]]
 function transfer_inventory(args)
    args.name = args.name or ""
    args.ratio = args.ratio or 1

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -4596,7 +4596,7 @@ script.on_event("control-click", function(event)
             local inv_full = false
             local announce_limit = 4 --List at most this number of moved stacks
             local stack_name = " "
-            "for every stack in the selected building inventory do" --todo correctly phrase this line
+            for i = 1,2,1 do --todo correctly phrase this line as: "for every stack in the selected building inventory do"
                local stack = players[pindex].building.sectors[players[pindex].building.sector].inventory[players[pindex].building.index]
                if stack.valid and stack.valid_for_read then
                   if game.get_player(pindex).can_insert(stack) then
@@ -4640,7 +4640,7 @@ script.on_event("control-click", function(event)
                local inv_full = false
                local announce_limit = 4 --List at most this number of moved stacks
                local stack_name = " "
-               "for every stack in the player inventory do" --todo correctly phrase this line
+               for i = 1,2,1 do --todo correctly phrase this line as: "for every stack in the player inventory do"
                   local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
                   if stack.valid and stack.valid_for_read then
                      if players[pindex].building.ent.can_insert(stack) then

--- a/mods/FactorioAccess/data-updates.lua
+++ b/mods/FactorioAccess/data-updates.lua
@@ -1,11 +1,16 @@
 
 for name, proto in pairs(data.raw.item) do
-   if not proto.localised_description and proto.place_result then
-      local pr = proto.place_result
+   local pr = proto.place_result
+   if pr then
       if pr.name then
          pr = pr.name
       end
-      proto.localised_description = { "entity-description." .. pr }
+      if not proto.localised_description then
+         proto.localised_description = { "entity-description." .. pr }
+      end
+      if not proto.localised_name then
+         proto.localised_name = { "entity-name." .. pr }
+      end
    end
 end
 

--- a/mods/FactorioAccess/data.lua
+++ b/mods/FactorioAccess/data.lua
@@ -461,6 +461,13 @@ data:extend({
 
 {
     type = "custom-input",
+    name = "control-click",
+    key_sequence = "CONTROL + LEFTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
     name = "item-info",
     key_sequence = "L",
     consuming = "none"

--- a/mods/FactorioAccess/data.lua
+++ b/mods/FactorioAccess/data.lua
@@ -468,6 +468,13 @@ data:extend({
 
 {
     type = "custom-input",
+    name = "control-right-click",
+    key_sequence = "CONTROL + RIGHTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
     name = "item-info",
     key_sequence = "L",
     consuming = "none"

--- a/mods/FactorioAccess/locale/en/factorio-access.cfg
+++ b/mods/FactorioAccess/locale/en/factorio-access.cfg
@@ -5,3 +5,8 @@ cursor-description=__1____plural_for_parameter_2_{0=|1= __3__}__ __4__ in hand__
 cursor-description-verbose=The item type in your hand is __1__ __plural_for_parameter_2_{0=which is either not a building or doesn't support rotation|1=which if you were to build it, then it would be __3__}__. There are __4__ of them in your hand and __plural_for_parameter_5_{0=no more in your inventory|rest=you have __5__ total}__.}__
 empty_cursor=Empty hand
 empty_cursor-verbose=You currently don't have anything in your hand.
+grabbed-stuff=Grabbed __1__
+item-quantity=__1__ x __2__
+grabbed-nothing=Grabbed nothing
+placed-stuff=Placed __1__
+placed-nothing=Placed nothing


### PR DESCRIPTION
UPDATE:
-Adds the vanilla shortcut of control + click in inventory menus, which is:
-Control + left bracket on an item in an inventory to smart transfer all of it.
-Control + right bracket on an item in an inventory to smart transfer half of it.
-Control + left bracket on an empty slot in an inventory to smart transfer all items.
-Control + right bracket on an empty slot in an inventory to smart transfer half of every item.
