### PR TITLE
Recategorize rocks as resources

### DIFF
--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -1451,7 +1451,7 @@ function populate_categories(pindex)
          print("Empty ent")
       elseif ent.name == "water" then
          table.insert(players[pindex].nearby.resources, ent)      
-      elseif ent.ents[1].type == "resource" or ent.ents[1].type == "tree" then
+      elseif ent.ents[1].type == "resource" or ent.ents[1].type == "tree" or ent.ents[1].type == "rock-big" or ent.ents[1].type == "rock-huge" then
          table.insert(players[pindex].nearby.resources, ent)
       elseif ent.ents[1].type == "container" then
          table.insert(players[pindex].nearby.containers, ent)

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -1451,7 +1451,7 @@ function populate_categories(pindex)
          print("Empty ent")
       elseif ent.name == "water" then
          table.insert(players[pindex].nearby.resources, ent)      
-      elseif ent.ents[1].type == "resource" or ent.ents[1].type == "tree" or ent.ents[1].type == "rock-big" or ent.ents[1].type == "rock-huge" then
+      elseif ent.ents[1].type == "resource" or ent.ents[1].type == "tree" or ent.ents[1].name == "sand-rock-big" or ent.ents[1].name == "rock-big" or ent.ents[1].name == "rock-huge" then --Note: There is no rock type, so they are specified by name.
          table.insert(players[pindex].nearby.resources, ent)
       elseif ent.ents[1].type == "container" then
          table.insert(players[pindex].nearby.containers, ent)


### PR DESCRIPTION
Recategorizes rocks as resources in the scanner.

I think this makes sense because they provide stone and coal, and are excellent for that in the early game. However, feel free to refuse if you disagree.
