### PR TITLE
Added drag-placing of entities.

### DIFF
--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -5131,6 +5131,10 @@ script.on_event("cursor-drag-leftt", function(event)
    move_drag_place(defines.direction.west,event)
 end)
 
+--[[Assuming the player is holding the build key while moving, this function attempts to move the cursor and/or player and then build the item held in the cursor hand 
+* Needed mainly for efficiently placing pipes and transport belts.
+* todo needs testing. Maybe limit it to only 1 by 1 entities? 
+]]
 function move_drag_place(direction, event)
    local pindex = event.player_index
    if not check_for_player(pindex) or players[pindex].menu == "prompt" then
@@ -5145,19 +5149,16 @@ function move_drag_place(direction, event)
    move_key(direction, event)
    
    --Build the item in hand
-   local stack = game.get_player(pindex).cursor_stack
-   if stack.valid_for_read and stack.valid then
-      if stack.name ~= "offshore-pump" then
-         build_item_in_hand(pindex, stack)
-      else
-         build_offshore_pump_in_hand(pindex, stack)
-      end
-   end
+   build_item_in_hand(pindex)
 end
 
-
-function build_item_in_hand(pindex, stack)
-   --Copy lines from script.on_event("left-click", function(event)
+--[[Attempts to build the item in hand.
+* Does nothing if the hand is empty or the item is not a place-able entity.
+* If the item is an offshore pump, calls a different, special function for it.
+]]
+function build_item_in_hand(pindex)
+   local stack = game.get_player(pindex).cursor_stack
+   --Copying lines from script.on_event("left-click", function(event) ; todo: it would be best to remove the lines from there and just call this function instead
    --(copy starts at "if stack.valid_for_read and stack.valid and stack.prototype.place_result ~= nil and stack.name ~= "offshore-pump" then", include this line)
    if stack.valid_for_read and stack.valid and stack.prototype.place_result ~= nil and stack.name ~= "offshore-pump" then
 	 local ent = stack.prototype.place_result
@@ -5219,12 +5220,18 @@ function build_item_in_hand(pindex, stack)
 		printout("Cannot place that there.", pindex)
 		print(players[pindex].player_direction .. " " .. game.get_player(pindex).character.position.x .. " " .. game.get_player(pindex).character.position.y .. " " .. players[pindex].cursor_pos.x .. " " .. players[pindex].cursor_pos.y .. " " .. position.x .. " " .. position.y)
 	 end
+   --(copy ends at "elseif stack.valid and stack.valid_for_read and stack.name == "offshore-pump" then", including this line)
+   elseif stack.valid and stack.valid_for_read and stack.name == "offshore-pump" then
+      build_offshore_pump_in_hand(pindex)
    end
-   --(copy ends at "elseif stack.valid and stack.valid_for_read and stack.name == "offshore-pump" then", exclude this line)
 end
 
-function build_offshore_pump_in_hand(pindex, stack)
-   --Copy lines from script.on_event("left-click", function(event)
+--[[Assisted building function for offshore pumps.
+* Called as a special case by build_item_in_hand
+]]
+function build_offshore_pump_in_hand(pindex)
+   local stack = game.get_player(pindex).cursor_stack
+   --Copying lines from script.on_event("left-click", function(event) ; todo: it would be best to remove the lines from there and just call this function instead
    --(copy starts with "elseif stack.valid and stack.valid_for_read and stack.name == "offshore-pump" then", include this line)
    if stack.valid and stack.valid_for_read and stack.name == "offshore-pump" then
 	  local ent = stack.prototype.place_result

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -5157,25 +5157,24 @@ script.on_event("nudge-right", function(event)
    nudge_key(defines.direction.east,event)
 end)
 
---Drag and place in your direction
+--Drag and place while stepping forward
 script.on_event("alt-click", function(event)
-   local direction = players[event.player_index].player_direction
-   move_drag_place(direction,event)
+   move_drag_place(event, 1)
 end)
 
 --Drag and place while stepping backward
 script.on_event("alt-right-click", function(event)
-   local direction = players[event.player_index].player_direction
-   move_drag_place(direction,event, 1)
+   move_drag_place(event, 0)
 end)
 
 
---[[Assuming the player is holding the build key while moving, this function attempts to move the cursor and/or player and then build the item held in the cursor hand 
+--[[Moves the player forward and places the item in hand. 
 * Needed mainly for efficiently placing pipes and transport belts.
-* If you set "forward" to false the engineer takes a step back and then tries to place the item. Great for laying down rows of machines.
+* If you set the parameter "forward" to 0, the engineer takes a step back and then tries to place the item. Great for laying down rows of machines.
 ]]
-function move_drag_place(direction, event, forward)
-   forward =  forward or 0
+function move_drag_place(event, forward)
+   local direction = players[event.player_index].player_direction
+   forward =  forward or 1
    local pindex = event.player_index
    if not check_for_player(pindex) or players[pindex].menu == "prompt" then
       return 
@@ -5185,8 +5184,8 @@ function move_drag_place(direction, event, forward)
       return
    end
    
-   --Move player as normal in that direction / Move the cursor in cursor mode (both use same fn?)
-   if forward == 0 then
+   --Move the player
+   if forward == 1 then
       move_key(direction, event)
    else
       step_backward(direction, event.player_index)

--- a/mods/FactorioAccess/data.lua
+++ b/mods/FactorioAccess/data.lua
@@ -461,15 +461,15 @@ data:extend({
 
 {
     type = "custom-input",
-    name = "alt-click",
-    key_sequence = "ALT + LEFTBRACKET",
+    name = "CAPSLOCK",
+    key_sequence = "CAPSLOCK",
     consuming = "none"
 },
 
 {
     type = "custom-input",
-    name = "alt-right-click",
-    key_sequence = "ALT + RIGHTBRACKET",
+    name = "BACKSPACE",
+    key_sequence = "BACKSPACE",
     consuming = "none"
 },
 

--- a/mods/FactorioAccess/data.lua
+++ b/mods/FactorioAccess/data.lua
@@ -461,6 +461,34 @@ data:extend({
 
 {
     type = "custom-input",
+    name = "cursor-drag-up",
+    key_sequence = "W + LEFTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "cursor-drag-right",
+    key_sequence = "D + LEFTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "cursor-drag-down",
+    key_sequence = "S + LEFTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
+    name = "cursor-drag-left",
+    key_sequence = "A + LEFTBRACKET",
+    consuming = "none"
+},
+
+{
+    type = "custom-input",
     name = "item-info",
     key_sequence = "L",
     consuming = "none"

--- a/mods/FactorioAccess/data.lua
+++ b/mods/FactorioAccess/data.lua
@@ -461,29 +461,15 @@ data:extend({
 
 {
     type = "custom-input",
-    name = "cursor-drag-up",
-    key_sequence = "W + LEFTBRACKET",
+    name = "alt-click",
+    key_sequence = "ALT + LEFTBRACKET",
     consuming = "none"
 },
 
 {
     type = "custom-input",
-    name = "cursor-drag-right",
-    key_sequence = "D + LEFTBRACKET",
-    consuming = "none"
-},
-
-{
-    type = "custom-input",
-    name = "cursor-drag-down",
-    key_sequence = "S + LEFTBRACKET",
-    consuming = "none"
-},
-
-{
-    type = "custom-input",
-    name = "cursor-drag-left",
-    key_sequence = "A + LEFTBRACKET",
+    name = "alt-right-click",
+    key_sequence = "ALT + RIGHTBRACKET",
     consuming = "none"
 },
 


### PR DESCRIPTION
Latest version:
* Press CAPSLOCK to enabled/disable the "walk and build" mode.
* Independently, press BACKSPACE to take a step backward without turning. This is necessary for "walk and building" things that you cannot walk on.
Tested and ready to merge, if everyone likes it.