### PR TITLE
Identify transport belt parts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Version 0.3.1
 
-Updated 10/11/2022
+Updated 10/19/2022
 
 ## New Features
 
@@ -13,6 +13,8 @@ Updated 10/11/2022
 -Getting slot coordinates with the K key now works inside chests and most/all building menus.
 
 -In cursor mode, pressing J will announce that the cursor is returned to the player in addition to doing it.
+
+-Transport belt parts such as corners, junctions, and ends will now be specified when encountered.
 
 # Version 0.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Updated 10/19/2022
 
 -Build lock. When enabled, the game will continuously try to build behind the player as they walk, or under the cursor in cursor mode. Useful for tasks like building long transport belts. Press CONTROL + B to enable or disable. It also automatically gets disabled when you switch into or out of cursor mode or empty your hand and take a step.
 
+-Build lock has a special case for electric poles where it places an electric pole only if it is within 6.5 to 7.5 tiles of the nearest electric pole, allowing you to build lines of fully spaced out small electric poles by just walking.
+
 ## Changes
 
 -Getting item or entity information with the L key now works for entities on the surface and inside chests and most building menus.

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -309,6 +309,39 @@ function ent_info(pindex, ent, description)
    end
    
    if ent.type == "transport-belt" then
+      --Check if corner or junction or end
+      local sideload_count = 0
+      local backload_count = 0
+      local outload_count = 0
+      local inputs = ent.belt_neighbours["inputs"]
+      local outputs = ent.belt_neighbours["outputs"]
+      for i, belt in pairs(inputs) do
+         if ent.direction ~= belt.direction then
+            sideload_count = sideload_count + 1
+         else
+            backload_count = backload_count + 1
+         end
+      end
+      for i, belt in pairs(outputs) do
+         outload_count = outload_count + 1
+      end
+      if sideload_count == 0 and backload_count == 1 and outload_count == 1 then
+         result = result --middle (no need to specify)
+      elseif sideload_count == 0 and backload_count == 0 and outload_count == 0 then
+         result = result .. " unit "
+      elseif sideload_count == 0 and backload_count == 0 and outload_count == 1 then
+         result = result .. " start "
+      elseif sideload_count == 0 and backload_count == 1 and outload_count == 0 then
+         result = result .. " end "
+      elseif sideload_count == 1 and backload_count == 0 and outload_count == 0 then
+         result = result .. " end corner "
+      elseif sideload_count == 1 and backload_count == 0 and outload_count == 1 then
+         result = result .. " corner "
+      elseif sideload_count + backload_count > 1 then
+         result = result .. " junction " --maybe different junction types will be worth specifying in the future
+      end
+      
+      --Check contents
       local left = ent.get_transport_line(1).get_contents()
       local right = ent.get_transport_line(2).get_contents()
 

--- a/mods/FactorioAccess/control.lua
+++ b/mods/FactorioAccess/control.lua
@@ -5120,6 +5120,24 @@ function build_item_in_hand(pindex, offset_val)
          end
          position = offset_position(adjusted_position, players[pindex].player_direction, adjusted_offset)
       end
+      if stack.name == "small-electric-pole" and players[pindex].build_lock == true then
+         --Place a small electric pole in this position only if it is within 6.5 to 7.5 tiles of another small electric pole
+         local surf = game.get_player(pindex).surface
+         local small_poles = surf.find_entities_filtered{position = position, radius = 7.5, name = "small-electric-pole"}
+         local all_beyond_6_5 = true
+         local any_connects = false
+         for i,pole in ipairs(small_poles) do
+            if util.distance(position, pole.position) < 6.5 then
+               all_beyond_6_5 = false
+            elseif util.distance(position, pole.position) >= 6.5 then
+               any_connects = true
+            end
+         end
+         if not (all_beyond_6_5 and any_connects) then
+            game.get_player(pindex).play_sound{path = "Inventory-Move"}
+            return
+         end
+      end
       local building = {
          position = position,
          direction = players[pindex].building_direction * 2,
@@ -5131,9 +5149,9 @@ function build_item_in_hand(pindex, offset_val)
 --         read_tile(pindex)
       else
          if players[pindex].build_lock == true then
-            printout("Can't place.", pindex) 
-            --note: we want to mute this message entirely if build lock is on and the entity preventing the placement is the same as the item in hand
+            game.get_player(pindex).play_sound{path = "utility/cannot_build"}
          else
+            game.get_player(pindex).play_sound{path = "utility/cannot_build"}
             printout("Cannot place that there.", pindex)
          end
       end


### PR DESCRIPTION
-Belts label corners and junctions
-Belts label starts and ends
-When build lock is on, small electric poles connect only when 7 tiles (max distance) apart. They do not have full coverage during this, but it is meant for carrying power over long distances anyway.